### PR TITLE
プロフィール編集画面のUI

### DIFF
--- a/Packages/GodPackage/Sources/AppFeature/AppReducer.swift
+++ b/Packages/GodPackage/Sources/AppFeature/AppReducer.swift
@@ -17,7 +17,7 @@ public struct AppReducer: Reducer {
 
     var appDelegate = AppDelegateReducer.State()
     var sceneDelegate = SceneDelegateReducer.State()
-    var view = View.State.onboard()
+    var view = View.State.navigation()
 
     var quickActionURLs: [String: URL] = [
       "talk-to-founder": Constants.founderURL,

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -116,8 +116,8 @@ public struct ProfileEditView: View {
 
                         Spacer()
 
-                        Text("class of 2026")
-                            .font(.footnote)
+                        Text("Class of 2026")
+                            .font(.caption)
                             .foregroundColor(.godTextSecondaryLight)
 
                         Text(Image(systemName: "chevron.right"))

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -3,6 +3,13 @@ import ComposableArchitecture
 import LabeledButton
 import ManageAccountFeature
 import SwiftUI
+import Colors
+
+public extension Divider {
+    func god() -> some View {
+        self.background(Color.god.separator)
+    }
+}
 
 public struct ProfileEditReducer: Reducer {
   public init() {}
@@ -57,6 +64,10 @@ public struct ProfileEditView: View {
     self.store = store
   }
 
+    @State private var firstName: String = "Tomoki"
+    @State private var lastName: String = "Tsukiyama"
+    @State private var username: String = "tomokisun"
+
   public var body: some View {
     WithViewStore(store, observe: { $0 }) { viewStore in
       ScrollView(.vertical) {
@@ -65,7 +76,67 @@ public struct ProfileEditView: View {
             .frame(width: 145, height: 145)
             .clipShape(Circle())
 
-          VStack(spacing: 8) {
+            userSettingsSection
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("SCHOOL")
+                    .font(.caption)
+                    .bold()
+                    .foregroundColor(.god.textSecondaryLight)
+
+                VStack(alignment: .center, spacing: 0) {
+                    HStack(alignment: .center, spacing: 8) {
+                        Text(Image(systemName: "house.fill"))
+                            .foregroundColor(.god.textSecondaryLight)
+                            .font(.body)
+
+                        Text("Las Vegas Academy of Arts")
+                            .font(.body)
+                            .foregroundColor(.god.black)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Text("＞")
+                            .font(.body)
+                            .foregroundColor(.god.textSecondaryLight)
+                    }
+                        .padding(.horizontal, 12)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                    separator
+                    HStack(alignment: .center, spacing: 8) {
+                        Text(Image(systemName: "graduationcap.fill"))
+                            .foregroundColor(.god.textSecondaryLight)
+                            .font(.body)
+
+                        Text("9th Grade")
+                            .font(.body)
+                            .foregroundColor(.god.black)
+
+                        Spacer()
+
+                        Text("class of 2026")
+                            .font(.footnote)
+                            .foregroundColor(.god.textSecondaryLight)
+
+                        Text("＞")
+                            .font(.body)
+                            .foregroundColor(.god.textSecondaryLight)
+                    }
+                        .padding(.horizontal, 12)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.god.separator)
+                )
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+              Text("ACCOUNT SETTING")
+                  .font(.caption)
+                  .bold()
+                  .foregroundColor(.god.textSecondaryLight)
             LabeledButton("Restore Purchases", systemImage: "clock.arrow.circlepath") {
               viewStore.send(.restorePurchasesButtonTapped)
             }
@@ -109,6 +180,99 @@ public struct ProfileEditView: View {
       )
     }
   }
+
+    private var separator: some View {
+        Color.god.separator
+            .frame(height: 1)
+            .frame(maxWidth: .infinity)
+    }
+
+    private var userSettingsSection: some View {
+        VStack(alignment: .center, spacing: 0) {
+            HStack(alignment: .center, spacing: 0) {
+                Text("First Name")
+                    .font(.body)
+                    .foregroundColor(.god.textSecondaryLight)
+                    .frame(width: 108, alignment: .leading)
+
+                TextField("", text: $firstName)
+                    .multilineTextAlignment(.leading)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.body)
+                    .foregroundColor(.god.black)
+            }
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+
+            separator
+
+            HStack(alignment: .center, spacing: 0) {
+                Text("Last Name")
+                    .font(.body)
+                    .foregroundColor(.god.textSecondaryLight)
+                    .frame(width: 108, alignment: .leading)
+
+                TextField("", text: $lastName)
+                    .multilineTextAlignment(.leading)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.body)
+                    .foregroundColor(.god.black)
+            }
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+
+            separator
+
+            HStack(alignment: .center, spacing: 0) {
+                Text("Username")
+                    .font(.body)
+                    .foregroundColor(.god.textSecondaryLight)
+                    .frame(width: 108, alignment: .leading)
+
+                TextField("", text: $username)
+                    .multilineTextAlignment(.leading)
+                    .textFieldStyle(PlainTextFieldStyle())
+                    .font(.body)
+                    .foregroundColor(.god.black)
+            }
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+
+            separator
+
+            Button(action: {
+
+            }, label: {
+                HStack(alignment: .center, spacing: 0) {
+                    Text("Gender")
+                        .font(.body)
+                        .foregroundColor(.god.textSecondaryLight)
+                        .frame(width: 108, alignment: .leading)
+
+                    Text("Boy")
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .font(.body)
+                        .foregroundColor(.god.black)
+
+                    // アイコン来るまでパワー実装
+                    Text("＞")
+                        .font(.body)
+                        .foregroundColor(.god.textSecondaryLight)
+                }
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+            })
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color.god.separator)
+        )
+    }
 }
 
 struct ProfileEditViewPreviews: PreviewProvider {

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -7,7 +7,7 @@ import Colors
 
 public extension Divider {
     func god() -> some View {
-        self.background(Color.god.separator)
+        self.background(Color.godSeparator)
     }
 }
 
@@ -82,22 +82,22 @@ public struct ProfileEditView: View {
                 Text("SCHOOL")
                     .font(.caption)
                     .bold()
-                    .foregroundColor(.god.textSecondaryLight)
+                    .foregroundColor(.godTextSecondaryLight)
 
                 VStack(alignment: .center, spacing: 0) {
                     HStack(alignment: .center, spacing: 8) {
                         Text(Image(systemName: "house.fill"))
-                            .foregroundColor(.god.textSecondaryLight)
+                            .foregroundColor(.godTextSecondaryLight)
                             .font(.body)
 
                         Text("Las Vegas Academy of Arts")
                             .font(.body)
-                            .foregroundColor(.god.black)
+                            .foregroundColor(.godBlack)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                         Text("＞")
                             .font(.body)
-                            .foregroundColor(.god.textSecondaryLight)
+                            .foregroundColor(.godTextSecondaryLight)
                     }
                         .padding(.horizontal, 12)
                         .frame(maxWidth: .infinity)
@@ -105,22 +105,22 @@ public struct ProfileEditView: View {
                     separator
                     HStack(alignment: .center, spacing: 8) {
                         Text(Image(systemName: "graduationcap.fill"))
-                            .foregroundColor(.god.textSecondaryLight)
+                            .foregroundColor(.godTextSecondaryLight)
                             .font(.body)
 
                         Text("9th Grade")
                             .font(.body)
-                            .foregroundColor(.god.black)
+                            .foregroundColor(.godBlack)
 
                         Spacer()
 
                         Text("class of 2026")
                             .font(.footnote)
-                            .foregroundColor(.god.textSecondaryLight)
+                            .foregroundColor(.godTextSecondaryLight)
 
                         Text("＞")
                             .font(.body)
-                            .foregroundColor(.god.textSecondaryLight)
+                            .foregroundColor(.godTextSecondaryLight)
                     }
                         .padding(.horizontal, 12)
                         .frame(maxWidth: .infinity)
@@ -128,7 +128,7 @@ public struct ProfileEditView: View {
                 }
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .stroke(Color.god.separator)
+                        .stroke(Color.godSeparator)
                 )
             }
 
@@ -136,7 +136,7 @@ public struct ProfileEditView: View {
               Text("ACCOUNT SETTING")
                   .font(.caption)
                   .bold()
-                  .foregroundColor(.god.textSecondaryLight)
+                  .foregroundColor(.godTextSecondaryLight)
             LabeledButton("Restore Purchases", systemImage: "clock.arrow.circlepath") {
               viewStore.send(.restorePurchasesButtonTapped)
             }
@@ -182,7 +182,7 @@ public struct ProfileEditView: View {
   }
 
     private var separator: some View {
-        Color.god.separator
+        Color.godSeparator
             .frame(height: 1)
             .frame(maxWidth: .infinity)
     }
@@ -192,14 +192,14 @@ public struct ProfileEditView: View {
             HStack(alignment: .center, spacing: 0) {
                 Text("First Name")
                     .font(.body)
-                    .foregroundColor(.god.textSecondaryLight)
+                    .foregroundColor(.godTextSecondaryLight)
                     .frame(width: 108, alignment: .leading)
 
                 TextField("", text: $firstName)
                     .multilineTextAlignment(.leading)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.body)
-                    .foregroundColor(.god.black)
+                    .foregroundColor(.godBlack)
             }
                 .padding(.horizontal, 12)
                 .frame(maxWidth: .infinity)
@@ -210,14 +210,14 @@ public struct ProfileEditView: View {
             HStack(alignment: .center, spacing: 0) {
                 Text("Last Name")
                     .font(.body)
-                    .foregroundColor(.god.textSecondaryLight)
+                    .foregroundColor(.godTextSecondaryLight)
                     .frame(width: 108, alignment: .leading)
 
                 TextField("", text: $lastName)
                     .multilineTextAlignment(.leading)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.body)
-                    .foregroundColor(.god.black)
+                    .foregroundColor(.godBlack)
             }
                 .padding(.horizontal, 12)
                 .frame(maxWidth: .infinity)
@@ -228,14 +228,14 @@ public struct ProfileEditView: View {
             HStack(alignment: .center, spacing: 0) {
                 Text("Username")
                     .font(.body)
-                    .foregroundColor(.god.textSecondaryLight)
+                    .foregroundColor(.godTextSecondaryLight)
                     .frame(width: 108, alignment: .leading)
 
                 TextField("", text: $username)
                     .multilineTextAlignment(.leading)
                     .textFieldStyle(PlainTextFieldStyle())
                     .font(.body)
-                    .foregroundColor(.god.black)
+                    .foregroundColor(.godBlack)
             }
                 .padding(.horizontal, 12)
                 .frame(maxWidth: .infinity)
@@ -249,19 +249,19 @@ public struct ProfileEditView: View {
                 HStack(alignment: .center, spacing: 0) {
                     Text("Gender")
                         .font(.body)
-                        .foregroundColor(.god.textSecondaryLight)
+                        .foregroundColor(.godTextSecondaryLight)
                         .frame(width: 108, alignment: .leading)
 
                     Text("Boy")
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.body)
-                        .foregroundColor(.god.black)
+                        .foregroundColor(.godBlack)
 
                     // アイコン来るまでパワー実装
                     Text("＞")
                         .font(.body)
-                        .foregroundColor(.god.textSecondaryLight)
+                        .foregroundColor(.godTextSecondaryLight)
                 }
                 .padding(.horizontal, 12)
                 .frame(maxWidth: .infinity)
@@ -270,7 +270,7 @@ public struct ProfileEditView: View {
         }
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.god.separator)
+                .stroke(Color.godSeparator)
         )
     }
 }

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -89,7 +89,7 @@ public struct ProfileEditView: View {
                             .foregroundColor(.godBlack)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Text("＞")
+                        Text(Image(systemName: "chevron.right"))
                             .font(.body)
                             .foregroundColor(.godTextSecondaryLight)
                     }
@@ -112,7 +112,7 @@ public struct ProfileEditView: View {
                             .font(.footnote)
                             .foregroundColor(.godTextSecondaryLight)
 
-                        Text("＞")
+                        Text(Image(systemName: "chevron.right"))
                             .font(.body)
                             .foregroundColor(.godTextSecondaryLight)
                     }
@@ -253,7 +253,7 @@ public struct ProfileEditView: View {
                         .foregroundColor(.godBlack)
 
                     // アイコン来るまでパワー実装
-                    Text("＞")
+                    Text(Image(systemName: "chevron.right"))
                         .font(.body)
                         .foregroundColor(.godTextSecondaryLight)
                 }

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -5,12 +5,6 @@ import ManageAccountFeature
 import SwiftUI
 import Colors
 
-public extension Divider {
-    func god() -> some View {
-        self.background(Color.godSeparator)
-    }
-}
-
 public struct ProfileEditReducer: Reducer {
   public init() {}
 

--- a/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
+++ b/Packages/GodPackage/Sources/ProfileEditFeature/ProfileEdit.swift
@@ -69,6 +69,14 @@ public struct ProfileEditView: View {
           Color.green
             .frame(width: 145, height: 145)
             .clipShape(Circle())
+            .overlay(
+                Image(systemName: "camera.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .foregroundColor(.godWhite)
+                    .frame(width: 40, height: 40)
+                    .shadow(color: .godBlack.opacity(0.5), radius: 4, y: 2)
+            )
 
             userSettingsSection
 
@@ -252,7 +260,6 @@ public struct ProfileEditView: View {
                         .font(.body)
                         .foregroundColor(.godBlack)
 
-                    // アイコン来るまでパワー実装
                     Text(Image(systemName: "chevron.right"))
                         .font(.body)
                         .foregroundColor(.godTextSecondaryLight)

--- a/Packages/UIComponentPackage/Sources/ButtonStyles/CornerRadiusBorderButtonStyle.swift
+++ b/Packages/UIComponentPackage/Sources/ButtonStyles/CornerRadiusBorderButtonStyle.swift
@@ -15,11 +15,3 @@ public struct CornerRadiusBorderButtonStyle: ButtonStyle {
       )
   }
 }
-
-public struct BorderFormStyle: FormStyle {
-
-    public func makeBody(configuration: Configuration) -> some View {
-        configuration.content
-            .padding()
-    }
-}

--- a/Packages/UIComponentPackage/Sources/ButtonStyles/CornerRadiusBorderButtonStyle.swift
+++ b/Packages/UIComponentPackage/Sources/ButtonStyles/CornerRadiusBorderButtonStyle.swift
@@ -15,3 +15,11 @@ public struct CornerRadiusBorderButtonStyle: ButtonStyle {
       )
   }
 }
+
+public struct BorderFormStyle: FormStyle {
+
+    public func makeBody(configuration: Configuration) -> some View {
+        configuration.content
+            .padding()
+    }
+}


### PR DESCRIPTION

コンポーネント化はサーバーとの繋ぎ込み時の方が都合がいいのでこのPRでは対応しない

### TODO
- [x] 右矢印の素材がなかったため>を代用しているのを治す

<img src="https://github.com/0x1-company/god-ios/assets/48109224/0bcec2a7-7537-4045-b325-c27d920a239b" width=320 />
